### PR TITLE
Update to Mailer.php to fix attach function

### DIFF
--- a/core/components/modhelpers/classes/Mailer.php
+++ b/core/components/modhelpers/classes/Mailer.php
@@ -273,7 +273,7 @@ class Mailer
             if (isset($this->attributes['setHTML'])) $this->mailer->setHTML($this->attributes['setHTML']);
             if (!empty($this->attributes['attach'])) {
                 foreach ($this->attributes['attach'] as $data) {
-                    list($file, $name, $encoding, $type) = $data;
+                    list($file, $name, $encoding, $type) = array_values($data);
                     $this->mailer->attach($file, $name, $encoding, $type);
                 }
             }


### PR DESCRIPTION
Hey @sergant210 - I discovered an issue where the mailer function was not attaching files provided to it, putting up this PR as this is what resolved it for me. 

**Details**
`$data` returns an associative array which `list()` doesn't know how to handle, which causes it to not actually attach a file provided. 

Adding `array_values` around `$data` on line 276 will return `$data` as an indexed array which `list()` is able to parse. 

This seems to resolve the issue of files not attaching to emails that are sent.