### PR TITLE
Update str_contains in isJson function

### DIFF
--- a/core/components/modhelpers/classes/Request.php
+++ b/core/components/modhelpers/classes/Request.php
@@ -217,7 +217,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function isJson()
     {
-        return str_contains($this->header('CONTENT_TYPE'), ['/json', '+json']);
+        return str_contains($this->header('CONTENT_TYPE'), '+json') || str_contains($this->header('CONTENT_TYPE'), '/json');
     }
 
     /**


### PR DESCRIPTION
The second param of `str_contains` only supports strings, not arrays. 

I noticed this caused a fatal 500 error when used with Modx 3.0. 

This change updates it so that the values checked are both strings.

*Edit: Apologies @sergant210, I forgot to tag you. 